### PR TITLE
Fix missing UI bug

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -160,11 +160,10 @@ const main = () => {
     }
     const observer = new MutationObserver(respondToMutation);
 
-    observer.observe(targetNode, observerOptions);
+    if (targetNode) observer.observe(targetNode, observerOptions);
     document.onkeydown = captureHotkeys;
 }
 
-if (/\/pull\//.test(window.location.pathname)) {
-    document.addEventListener("pjax:end", main);
-    document.addEventListener("DOMContentLoaded", main);
-}
+// This mostly works.
+document.addEventListener("DOMContentLoaded", main);
+document.addEventListener("pjax:end", main);


### PR DESCRIPTION
When navigating to the files tab in the GitHub UI, this extension
doesn't really load correctly. This change *should* fix that bug and
still work when navigating directly to the files tab from another URL.

Closes #11 